### PR TITLE
Incorrect condition in the getSecuritytxt function

### DIFF
--- a/Security-txt/scripts/background.js
+++ b/Security-txt/scripts/background.js
@@ -14,7 +14,7 @@ function changeIcon(tabid, exists){
 
 function getSecuritytxt(domain, protocol, wk, tabid){
 	xhr = new XMLHttpRequest; xhr.open("GET", protocol+domain+wk+'security.txt'); xhr.onreadystatechange = function(){
-		if(xhr.status != 404 && xhr.getResponseHeader('content-type').startsWith('text/plain') && xhr.responseText.indexOf('Contact:')){
+		if(xhr.status != 404 && xhr.getResponseHeader('content-type').startsWith('text/plain') && xhr.responseText.indexOf('Contact:')!=-1){
 			UpdateStorage('hasSecuritytxt', 'set', domain+':'+wk);
 			changeIcon(tabid, true);
 		}else{


### PR DESCRIPTION
Hello. I discovered, that 
```
if(xhr.status != 404 && xhr.getResponseHeader('content-type').startsWith('text/plain') && xhr.responseText.indexOf('Contact:'))
```
condition can work in the wrong way, if `Contact:` string exists in the beginning of the `security.txt` file.
In this case `xhr.responseText.indexOf('Contact:')` will return 0, and will be interpreted as false (icon will stay Red, despite security.txt exist and was fetched correctly). As result, `UpdateStorage('hasSecuritytxt', 'set', domain+':'+wk);` will be never reached too.
Proposed change:
change the condition from
```
xhr.responseText.indexOf('Contact:')
```
to the
```
xhr.responseText.indexOf('Contact:')!=-1
```