### PR TITLE
Mitigating extension self-DOS when browsing the different sites

### DIFF
--- a/Security-txt/scripts/background.js
+++ b/Security-txt/scripts/background.js
@@ -1,50 +1,61 @@
-function changeIcon(tabid, exists){
-	if(exists){
-		chrome.browserAction.setIcon({
-			path: "icons/icon1.png",
-			tabId: tabid
-		})
-	}else{
-		chrome.browserAction.setIcon({
-			path: "icons/icon2.png",
-			tabId: tabid
-		})
-	}
+function changeIcon(tabid, exists) {
+    if (exists) {
+        chrome.browserAction.setIcon({
+            path: "icons/icon1.png",
+            tabId: tabid
+        })
+    } else {
+        chrome.browserAction.setIcon({
+            path: "icons/icon2.png",
+            tabId: tabid
+        })
+    }
 }
 
-function getSecuritytxt(domain, protocol, wk, tabid){
-	xhr = new XMLHttpRequest; xhr.open("GET", protocol+domain+wk+'security.txt'); xhr.onreadystatechange = function(){
-		if(xhr.status != 404 && xhr.getResponseHeader('content-type').startsWith('text/plain') && xhr.responseText.indexOf('Contact:')!=-1){
-			UpdateStorage('hasSecuritytxt', 'set', domain+':'+wk);
-			changeIcon(tabid, true);
-		}else{
-			changeIcon(tabid, false);
-			return false
-		}
-	}; xhr.send();
+function getSecuritytxt(domain, protocol, wk, tabid) {
+    xhr = new XMLHttpRequest;
+    xhr.open("GET", protocol + domain + wk + 'security.txt');
+    xhr.timeout = 10000;
+    xhr.onreadystatechange = function() {
+        if (xhr.status != 404 && xhr.getResponseHeader('content-type').startsWith('text/plain') && xhr.responseText.indexOf('Contact:') != -1) {
+            UpdateStorage('hasSecuritytxt', 'set', domain + ':' + wk);
+            changeIcon(tabid, true);
+        } else {
+            changeIcon(tabid, false);
+            return false
+        }
+    };
+    xhr.send();
 }
 
-function UpdateStorage(path, action, value){
-	chrome.storage.local.get(function(callback){
-		storage = callback;
-		if(Object.keys(storage).length == 0){
-			chrome.storage.local.set({"hasSecuritytxt":[], "location":[]})
-		};
-		if(path == 'hasSecuritytxt'){
-			if(action == 'set' && storage.hasSecuritytxt.indexOf(value.split(':')[0]) < 0){
-				storage.hasSecuritytxt.push(value.split(':')[0]);
-				storage.location.push(value.split(':')[1])
-			}
-		}; chrome.storage.local.set(storage);
-	})
+function UpdateStorage(path, action, value) {
+    chrome.storage.local.get(function(callback) {
+        storage = callback;
+        if (Object.keys(storage).length == 0) {
+            chrome.storage.local.set({
+                "hasSecuritytxt": [],
+                "location": []
+            })
+        };
+        if (path == 'hasSecuritytxt') {
+            if (action == 'set' && storage.hasSecuritytxt.indexOf(value.split(':')[0]) < 0) {
+                storage.hasSecuritytxt.push(value.split(':')[0]);
+                storage.location.push(value.split(':')[1])
+            }
+        };
+        chrome.storage.local.set(storage);
+    })
 }
 
-chrome.runtime.onMessage.addListener(function(message, sender, response){
-	if(message.securityTxt != undefined && message.securityTxt){
-		if(getSecuritytxt(message.securityTxt[0].domain, message.securityTxt[0].protocol, "/", sender.tab.id) == false){
-			getSecuritytxt(message.securityTxt[0].domain, message.securityTxt[0].protocol, "/.well-known/", sender.tab.id)
-		}
-	}
+chrome.runtime.onMessage.addListener(function(message, sender, response) {
+    if (message.securityTxt != undefined && message.securityTxt) {
+        if (getSecuritytxt(message.securityTxt[0].domain, message.securityTxt[0].protocol, "/", sender.tab.id) == false) {
+            getSecuritytxt(message.securityTxt[0].domain, message.securityTxt[0].protocol, "/.well-known/", sender.tab.id)
+        }
+    }
 })
 
-chrome.storage.onChanged.addListener(function(){UpdateStorage()}); UpdateStorage();
+chrome.storage.onChanged.addListener(function() {
+    UpdateStorage()
+});
+UpdateStorage();

--- a/Security-txt/scripts/popup.js
+++ b/Security-txt/scripts/popup.js
@@ -1,5 +1,9 @@
-document.getElementById("defaultOpen").addEventListener("click", function(event){openTab(event, "securitytxt-content")})
-document.getElementById("History").addEventListener("click", function(event){openTab(event, "Historytab")})
+document.getElementById("defaultOpen").addEventListener("click", function(event) {
+    openTab(event, "securitytxt-content")
+})
+document.getElementById("History").addEventListener("click", function(event) {
+    openTab(event, "Historytab")
+})
 document.getElementById("defaultOpen").click();
 
 function openTab(evt, tabid) {
@@ -16,23 +20,31 @@ function openTab(evt, tabid) {
     evt.currentTarget.className += " active";
 }
 
-function LoadFromStorage(){
-    chrome.storage.local.get(function(callback){
+function LoadFromStorage() {
+    chrome.storage.local.get(function(callback) {
         storage = callback;
-        query = { active: true, currentWindow: true };
-        chrome.tabs.query(query, function(result){
+        query = {
+            active: true,
+            currentWindow: true
+        };
+        chrome.tabs.query(query, function(result) {
             domain = result[0].url.split('/')[2];
-            if(storage.hasSecuritytxt.indexOf(domain) > -1){
-                xhr = new XMLHttpRequest; xhr.onreadystatechange = function(){
+            if (storage.hasSecuritytxt.indexOf(domain) > -1) {
+                xhr = new XMLHttpRequest;
+                xhr.timeout = 10000;
+                xhr.ontimeout = function(e) {
+                    document.getElementById("securitytxt-pre").innerHTML = "Error: security.txt file is too big or is taking too long to retrieve.";
+                };
+                xhr.onreadystatechange = function() {
                     //It shouldn't be possible to XSS this but just in case.
                     contents = $('<div/>').text(xhr.responseText).html();
                     document.getElementById("securitytxt-pre").innerHTML = contents;
                 };
 
-                if(storage.location[storage.hasSecuritytxt.indexOf(domain)] == '/'){
-                    xhr.open("GET", result[0].url.split('/')[0]+'//'+domain+'/security.txt');
-                }else{
-                    xhr.open("GET", result[0].url.split('/')[0]+'//'+domain+'/.well-known/security.txt');
+                if (storage.location[storage.hasSecuritytxt.indexOf(domain)] == '/') {
+                    xhr.open("GET", result[0].url.split('/')[0] + '//' + domain + '/security.txt');
+                } else {
+                    xhr.open("GET", result[0].url.split('/')[0] + '//' + domain + '/.well-known/security.txt');
                 };
 
                 xhr.send();


### PR DESCRIPTION
Reported in the https://hackerone.com/reports/290955
Changes:
In the background.js added next line to the `getSecuritytxt` function:
```
xhr.timeout = 10000;
```
In the popup.js added next lines to the `LoadFromStorage` function
```
xhr.timeout = 10000;
xhr.ontimeout = function(e) {
document.getElementById("securitytxt-pre").innerHTML = "Error: security.txt file is too big or is taking too long to retrieve.";
};
```
You can adjust the timeouts as you like (currently it set to the 10 seconds).
How it works: upon first 10 seconds content from remote server still being retrieved (and may display in the extension), but after crossing the line request aborted.
As side effect some code formatting (indents) was done unintentionally, my editor did it automatically:)
